### PR TITLE
fix(tests): properly configure child logger in unit tests

### DIFF
--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -1,0 +1,8 @@
+function configureMockLogger() {
+  const childLogger = { debug: jest.fn(), error: jest.fn() }
+  return { child: jest.fn(() => childLogger), debug: jest.fn(), error: console.error }
+}
+
+module.exports = {
+  configureMockLogger
+}

--- a/test/unit/lib/plugins/autolinks.test.js
+++ b/test/unit/lib/plugins/autolinks.test.js
@@ -1,11 +1,12 @@
 const Autolinks = require('../../../../lib/plugins/autolinks')
+const { configureMockLogger } = require('../../common')
 
 describe('Autolinks', () => {
   const repo = { owner: 'owner', repo: 'repo' }
   let github
 
   function configure (config) {
-    const log = { child: jest.fn(), debug: jest.fn(), error: console.error }
+    const log = configureMockLogger()
     const nop = false
     const errors = []
     return new Autolinks(nop, github, repo, config, log, errors)

--- a/test/unit/lib/plugins/branches.test.js
+++ b/test/unit/lib/plugins/branches.test.js
@@ -2,15 +2,13 @@
 
 const { when } = require('jest-when')
 const Branches = require('../../../../lib/plugins/branches')
+const { configureMockLogger } = require('../../common')
 
 describe('Branches', () => {
   let github
-  const log = jest.fn()
-  log.child = jest.fn()
-  log.debug = jest.fn()
-  log.error = jest.fn()
 
   function configure (config) {
+    const log = configureMockLogger()
     const noop = false
     const errors = []
     return new Branches(noop, github, { owner: 'bkeepers', repo: 'test' }, config, log, errors)

--- a/test/unit/lib/plugins/collaborators.test.js
+++ b/test/unit/lib/plugins/collaborators.test.js
@@ -1,10 +1,11 @@
 const Collaborators = require('../../../../lib/plugins/collaborators')
+const { configureMockLogger } = require('../../common')
 
 describe('Collaborators', () => {
   let github
 
   function configure (config) {
-    const log = { child: jest.fn(), debug: jest.fn(), error: console.error }
+    const log = configureMockLogger()
     const errors = []
     return new Collaborators(undefined, github, { owner: 'bkeepers', repo: 'test' }, config, log, errors)
   }

--- a/test/unit/lib/plugins/custom_properties.test.js
+++ b/test/unit/lib/plugins/custom_properties.test.js
@@ -1,11 +1,12 @@
 const CustomProperties = require('../../../../lib/plugins/custom_properties')
+const { configureMockLogger } = require('../../common')
 
 describe('CustomProperties', () => {
     let github
     const repo = { owner: 'owner', repo: 'repo' }
-    let log
 
     function configure (config) {
+        const log = configureMockLogger()
         const nop = false;
         const errors = []
         return new CustomProperties(nop, github, { owner: 'bkeepers', repo: 'test' }, config, log, errors)

--- a/test/unit/lib/plugins/environments.test.js
+++ b/test/unit/lib/plugins/environments.test.js
@@ -1,10 +1,12 @@
 const { when } = require('jest-when')
 const Environments = require('../../../../lib/plugins/environments')
+const { configureMockLogger } = require('../../common')
 
 describe('Environments', () => {
     let github
     const org = 'bkeepers'
     const repo = 'test'
+    const log = configureMockLogger()
 
     function fillEnvironment(attrs) {
         if (!attrs.wait_timer) attrs.wait_timer = 0;
@@ -81,11 +83,7 @@ describe('Environments', () => {
                     }
                 ]
             }
-        ], {
-            child: function() {},
-            debug: function() {},
-            error: function() {},
-        }, []);
+        ], log, []);
 
         when(github.request)
             .calledWith('GET /repos/:org/:repo/environments', { org, repo })

--- a/test/unit/lib/plugins/labels.test.js
+++ b/test/unit/lib/plugins/labels.test.js
@@ -1,10 +1,11 @@
 const Labels = require('../../../../lib/plugins/labels')
+const { configureMockLogger } = require('../../common')
 
 describe('Labels', () => {
   let github
-  let log
 
   function configure(config) {
+    const log = configureMockLogger()
     const nop = false;
     const errors = []
     return new Labels(nop, github, { owner: 'bkeepers', repo: 'test' }, config, log, errors)

--- a/test/unit/lib/plugins/repository.test.js
+++ b/test/unit/lib/plugins/repository.test.js
@@ -1,4 +1,5 @@
 const Repository = require('../../../../lib/plugins/repository')
+const { configureMockLogger } = require('../../common')
 
 describe('Repository', () => {
   const github = {
@@ -12,12 +13,9 @@ describe('Repository', () => {
       replaceAllTopics: jest.fn().mockResolvedValue()
     }
   }
-  const log = jest.fn()
-  log.child = jest.fn()
-  log.debug = jest.fn()
-  log.error = jest.fn()
 
   function configure (config) {
+    const log = configureMockLogger()
     const noop = false
     const errors = []
     return new Repository(noop, github, { owner: 'bkeepers', repo: 'test' }, config, 1, log, errors)

--- a/test/unit/lib/plugins/teams.test.js
+++ b/test/unit/lib/plugins/teams.test.js
@@ -1,6 +1,7 @@
 const { when } = require('jest-when')
 const any = require('@travi/any')
 const Teams = require('../../../../lib/plugins/teams')
+const { configureMockLogger } = require('../../common')
 
 describe('Teams', () => {
   let github
@@ -15,7 +16,7 @@ describe('Teams', () => {
   const org = 'bkeepers'
 
   function configure (config) {
-    const log = { child: jest.fn(), debug: jest.fn(), error: console.error }
+    const log = configureMockLogger()
     const errors = []
     return new Teams(undefined, github, { owner: 'bkeepers', repo: 'test' }, config, log, errors)
   }


### PR DESCRIPTION
In our version of safe-settings we make use of child loggers. During tests, these child loggers were not mocked, resulting in errors like `Cannot read property error`.

This PR introduces a common function to configure the loggers for tests, including the child loggers.