### PR TITLE
chore: stringify JSON objects in logs

### DIFF
--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -77,19 +77,17 @@ module.exports = class Diffable extends ErrorStash {
       let filteredEntries = this.filterEntries()
       // this.log.debug(`filtered entries are ${JSON.stringify(filteredEntries)}`)
       return this.find().then(existingRecords => {
-        this.log.debug(` ${JSON.stringify(existingRecords, null, 2)} \n\n ${JSON.stringify(filteredEntries, null, 2)} `)
+        this.log.debug(` ${JSON.stringify(existingRecords)} \n\n ${JSON.stringify(filteredEntries)} `)
 
         const mergeDeep = new MergeDeep(this.log, this.github, ignorableFields)
         const compare = mergeDeep.compareDeep(existingRecords, filteredEntries)
         const results = { msg: 'Changes found', additions: compare.additions, modifications: compare.modifications, deletions: compare.deletions }
-        this.log.debug(`Results of comparing ${this.constructor.name} diffable target ${JSON.stringify(existingRecords)} with source ${JSON.stringify(filteredEntries)} is ${results}`)
+        this.log.debug(`Results of comparing ${this.constructor.name} diffable target ${JSON.stringify(existingRecords)} with source ${JSON.stringify(filteredEntries)} is ${JSON.stringify(results)}`)
         if (!compare.hasChanges) {
-          this.log.debug(`There are no changes for ${this.constructor.name} for repo ${this.repo}. Skipping changes`)
+          this.log.debug(`There are no changes for ${this.constructor.name} for repo ${JSON.stringify(this.repo)}. Skipping changes`)
           return Promise.resolve()
-        } else {
-          if (this.nop) {
+        } else if (this.nop) {
             resArray.push(new NopCommand(this.constructor.name, this.repo, null, results, 'INFO'))
-          }
         }
 
         // Filter out all empty entries (usually from repo override)


### PR DESCRIPTION
Some logs were outputting [object Object] instead of the string value, this explicitly outputs strings of objects