### PR TITLE
feat: add feature flag for team creation

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -5,5 +5,7 @@ module.exports = {
   DEPLOYMENT_CONFIG_FILE: process.env.DEPLOYMENT_CONFIG_FILE || 'deployment-settings.yml',
   CREATE_PR_COMMENT: process.env.CREATE_PR_COMMENT || 'true',
   CREATE_ERROR_ISSUE: process.env.CREATE_ERROR_ISSUE || 'true',
-  BLOCK_REPO_RENAME_BY_HUMAN: process.env.BLOCK_REPO_RENAME_BY_HUMAN || 'false'
+  BLOCK_REPO_RENAME_BY_HUMAN: process.env.BLOCK_REPO_RENAME_BY_HUMAN || 'false',
+  // If set to true, then when a team is defined in the settings file, it will be created if it does not exist.
+  FEATURE_CREATE_TEAMS_IF_NOT_EXIST: process.env.FEATURE_CREATE_TEAMS_IF_NOT_EXIST || 'false'
 }

--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -1,5 +1,6 @@
 const Diffable = require('./diffable')
 const NopCommand = require('../nopcommand')
+const env = require('../env')
 
 const teamRepoEndpoint = '/orgs/:owner/teams/:team_slug/repos/:owner/:repo'
 module.exports = class Teams extends Diffable {
@@ -43,27 +44,31 @@ module.exports = class Teams extends Diffable {
       })
     }).catch(e => {
       if (e.status === 404) {
-        const createParam = {
-          org: this.repo.owner,
-          name: attrs.name
+        if (env.FEATURE_CREATE_TEAMS_IF_NOT_EXIST) {
+          const createParam = {
+            org: this.repo.owner,
+            name: attrs.name
+          }
+          if (attrs.privacy) {
+            createParam.privacy = attrs.privacy
+          }
+          this.log.debug(`Creating teams ${JSON.stringify(createParam)}`)
+          if (this.nop) {
+            return Promise.resolve([
+              new NopCommand(this.constructor.name, this.repo, this.github.teams.create.endpoint(createParam), 'Create Team')
+            ])
+          }
+          return this.github.teams.create(createParam).then(res => {
+            this.log.debug(`team ${createParam.name} created`)
+            existing = res.data
+            this.log.debug(`adding team ${attrs.name} to repo ${this.repo.repo}`)
+            return this.github.teams.addOrUpdateRepoPermissionsInOrg(this.toParams(existing, attrs))
+          }).catch(e => {
+            this.logError('Error adding team: ', e)
+          })
+        } else {
+          this.log.info(`Feature to create teams is disabled. Team ${attrs.name} not found`)
         }
-        if (attrs.privacy) {
-          createParam.privacy = attrs.privacy
-        }
-        this.log.debug(`Creating teams ${JSON.stringify(createParam)}`)
-        if (this.nop) {
-          return Promise.resolve([
-            new NopCommand(this.constructor.name, this.repo, this.github.teams.create.endpoint(createParam), 'Create Team')
-          ])
-        }
-        return this.github.teams.create(createParam).then(res => {
-          this.log.debug(`team ${createParam.name} created`)
-          existing = res.data
-          this.log.debug(`adding team ${attrs.name} to repo ${this.repo.repo}`)
-          return this.github.teams.addOrUpdateRepoPermissionsInOrg(this.toParams(existing, attrs))
-        }).catch(e => {
-          this.logError('Error adding team: ', e)
-        })
       }
     })
   }

--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -44,31 +44,31 @@ module.exports = class Teams extends Diffable {
       })
     }).catch(e => {
       if (e.status === 404) {
-        if (env.FEATURE_CREATE_TEAMS_IF_NOT_EXIST) {
-          const createParam = {
-            org: this.repo.owner,
-            name: attrs.name
-          }
-          if (attrs.privacy) {
-            createParam.privacy = attrs.privacy
-          }
-          this.log.debug(`Creating teams ${JSON.stringify(createParam)}`)
-          if (this.nop) {
-            return Promise.resolve([
-              new NopCommand(this.constructor.name, this.repo, this.github.teams.create.endpoint(createParam), 'Create Team')
-            ])
-          }
-          return this.github.teams.create(createParam).then(res => {
-            this.log.debug(`team ${createParam.name} created`)
-            existing = res.data
-            this.log.debug(`adding team ${attrs.name} to repo ${this.repo.repo}`)
-            return this.github.teams.addOrUpdateRepoPermissionsInOrg(this.toParams(existing, attrs))
-          }).catch(e => {
-            this.logError('Error adding team: ', e)
-          })
-        } else {
+        if (env.FEATURE_CREATE_TEAMS_IF_NOT_EXIST == 'false') {
           this.log.info(`Feature to create teams is disabled. Team ${attrs.name} not found`)
+          return
         }
+        const createParam = {
+          org: this.repo.owner,
+          name: attrs.name
+        }
+        if (attrs.privacy) {
+          createParam.privacy = attrs.privacy
+        }
+        this.log.debug(`Creating teams ${JSON.stringify(createParam)}`)
+        if (this.nop) {
+          return Promise.resolve([
+            new NopCommand(this.constructor.name, this.repo, this.github.teams.create.endpoint(createParam), 'Create Team')
+          ])
+        }
+        return this.github.teams.create(createParam).then(res => {
+          this.log.debug(`team ${createParam.name} created`)
+          existing = res.data
+          this.log.debug(`adding team ${attrs.name} to repo ${this.repo.repo}`)
+          return this.github.teams.addOrUpdateRepoPermissionsInOrg(this.toParams(existing, attrs))
+        }).catch(e => {
+          this.logError('Error adding team: ', e)
+        })
       }
     })
   }


### PR DESCRIPTION
Current behaviour creates a secret team if a team doesn't exist. This adds a feature flag to prevent creating teams unless the feature flag is set