### PR TITLE
fix(autolinks): mark autolink as changed when url template changes

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -98,7 +98,8 @@ class MergeDeep {
     for (const key in source) {
       // Logic specific for Github
       // API response includes urls for resources, or other ignorable fields; we can ignore them
-      if (key.indexOf('url') >= 0 || this.ignorableFields.indexOf(key) >= 0) {
+      //if (key.indexOf('url') >= 0 || this.ignorableFields.indexOf(key) >= 0) {
+      if ((key.indexOf('url') >= 0 && key != "url_template") || this.ignorableFields.indexOf(key) >= 0) {
         continue
       }
       const sourceValue = source[key]

--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -98,7 +98,6 @@ class MergeDeep {
     for (const key in source) {
       // Logic specific for Github
       // API response includes urls for resources, or other ignorable fields; we can ignore them
-      //if (key.indexOf('url') >= 0 || this.ignorableFields.indexOf(key) >= 0) {
       if ((key.indexOf('url') >= 0 && key != "url_template") || this.ignorableFields.indexOf(key) >= 0) {
         continue
       }

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -837,7 +837,7 @@ entries:
     const source = YAML.load(`
 entries:
 - key_prefix: ASDF-
-  url_template: https://jiranew.company.com/browse/ASDF-<num>
+  url_template: https://jira.company.com/browse/ASDF-<num>
 - key_prefix: BOLIGRAFO-
   url_template: https://jira.company.com/browse/BOLIGRAFO-<num>
   `)
@@ -857,14 +857,7 @@ entries:
           }
         ]
       },
-      modifications: {
-        entries: [
-          {
-            key_prefix: "ASDF-",
-            url_template: "https://jiranew.company.com/browse/ASDF-<num>"
-          }
-        ]
-      },
+      modifications: {},
       deletions: {
         entries: [ {
           key_prefix: "BOLSIGRAFO-",

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -837,14 +837,14 @@ entries:
     const source = YAML.load(`
 entries:
 - key_prefix: ASDF-
-  url_template: https://jira.company.com/browse/ASDF-<num>
+  url_template: https://jiranew.company.com/browse/ASDF-<num>
 - key_prefix: BOLIGRAFO-
   url_template: https://jira.company.com/browse/BOLIGRAFO-<num>
   `)
     const target = YAML.load(`
     entries:
     - key_prefix: ASDF-
-      url_template: https://jiranew.company.com/browse/ASDF-<num>
+      url_template: https://jira.company.com/browse/ASDF-<num>
     - key_prefix: BOLSIGRAFO-
       url_template: https://jira.company.com/browse/BOLIGRAFO-<num>
       `)
@@ -858,6 +858,12 @@ entries:
         ]
       },
       modifications: {
+        entries: [
+          {
+            key_prefix: "ASDF-",
+            url_template: "https://jiranew.company.com/browse/ASDF-<num>"
+          }
+        ]
       },
       deletions: {
         entries: [ {
@@ -865,6 +871,44 @@ entries:
           url_template: "https://jira.company.com/browse/BOLIGRAFO-<num>"
         },]
       },
+      hasChanges: true
+    }
+    const ignorableFields = []
+    const mockReturnGitHubContext = jest.fn().mockReturnValue({
+      request: () => {},
+    });
+    const mergeDeep = new MergeDeep(
+      log,
+      mockReturnGitHubContext,
+      ignorableFields
+    );
+    const merged = mergeDeep.compareDeep(target, source)
+    console.log(`diffs ${JSON.stringify(merged, null, 2)}`)
+    expect(merged).toEqual(expected)
+  })
+
+  it('Autolinks different url template', () => {
+    const source = YAML.load(`
+entries:
+- key_prefix: ASDF-
+  url_template: https://jiranew.company.com/browse/ASDF-<num>
+  `)
+    const target = YAML.load(`
+    entries:
+    - key_prefix: ASDF-
+      url_template: https://jira.company.com/browse/ASDF-<num>
+      `)
+    const expected = {
+      additions: {},
+      modifications: {
+        entries: [
+          {
+            key_prefix: "ASDF-",
+            url_template: "https://jiranew.company.com/browse/ASDF-<num>"
+          }
+        ]
+      },
+      deletions: {},
       hasChanges: true
     }
     const ignorableFields = []

--- a/test/unit/lib/plugins/autolinks.test.js
+++ b/test/unit/lib/plugins/autolinks.test.js
@@ -34,6 +34,7 @@ describe('Autolinks', () => {
         { key_prefix: 'NEW_ALPHA-UNDEFINED-', url_template: 'https://test/<num>' },
         { key_prefix: 'NEW_ALPHA-FALSE-', url_template: 'https://test/<num>', is_alphanumeric: false },
         { key_prefix: 'NEW_ALPHA-TRUE-', url_template: 'https://test/<num>', is_alphanumeric: true },
+        { key_prefix: 'NEW_URL_NEW_ALPHA-', url_template: 'https://new-url/<num>', is_alphanumeric: true },
       ])
 
       github.repos.listAutolinks.mockResolvedValueOnce({
@@ -47,6 +48,7 @@ describe('Autolinks', () => {
           { id: '7', key_prefix: 'NEW_ALPHA-UNDEFINED-', url_template: 'https://test/<num>', is_alphanumeric: false },
           { id: '8', key_prefix: 'NEW_ALPHA-FALSE-', url_template: 'https://test/<num>', is_alphanumeric: true },
           { id: '9', key_prefix: 'NEW_ALPHA-TRUE-', url_template: 'https://test/<num>', is_alphanumeric: false },
+          { id: '10', key_prefix: 'NEW_URL_NEW_ALPHA-', url_template: 'https://current-url/<num>', is_alphanumeric: false },
         ]
       })
 
@@ -139,9 +141,19 @@ describe('Autolinks', () => {
           is_alphanumeric: true,
            ...repo
         })
+        expect(github.repos.deleteAutolink).toHaveBeenCalledWith({
+          autolink_id: '10',
+           ...repo
+        })
+        expect(github.repos.createAutolink).toHaveBeenCalledWith({
+          key_prefix: 'NEW_URL_NEW_ALPHA-',
+          url_template: 'https://new-url/<num>',
+          is_alphanumeric: true,
+           ...repo
+        })
 
-        expect(github.repos.deleteAutolink).toHaveBeenCalledTimes(5)
-        expect(github.repos.createAutolink).toHaveBeenCalledTimes(5)
+        expect(github.repos.deleteAutolink).toHaveBeenCalledTimes(6)
+        expect(github.repos.createAutolink).toHaveBeenCalledTimes(6)
       })
     })
   })


### PR DESCRIPTION
The change is just a workaround to mitigate the current issue with rolling out https://github.com/tomtom-internal/admin/pull/2755.